### PR TITLE
Add Commander Deck Tuner project card

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -50,6 +50,30 @@
       <section id="projects" class="text-center">
         <div class="projects-container">
           <div class="project-card">
+            <h2>MTG: Commander Deck Tuner</h2>
+            <h4>April 2025 - Present</h4>
+            <p><strong>Association:</strong> Personal Project</p>
+            <p>
+              <strong>Technologies Used:</strong> React#, JavaScript, Scryfall
+              API, HTML, CSS
+            </p>
+            <p><strong>Role:</strong> Lead Developer</p>
+            <p>
+              Commander Deck Tuner is a React-based web application designed for
+              Magic: The Gathering players to build, customize, and manage their
+              Commander decks. Leveraging the Scryfall API, users can search for
+              cards, add them to decks, and view detailed deck statistics. The
+              app features a clean, responsive interface for seamless deck
+              management and card organization.
+            </p>
+            <a
+              href="https://github.com/hbrandon15/CommanderDeckTuner"
+              target="_blank"
+              rel="noopener"
+              >View Project</a
+            >
+          </div>
+          <div class="project-card">
             <h2>Pretrial Audit System</h2>
             <h4>Nov 2024 - Present</h4>
             <p><strong>Association:</strong> Harris County</p>
@@ -94,7 +118,7 @@
               href="https://github.com/hbrandon15/criminal-justice-kiosk"
               target="_blank"
               rel="noopener"
-              >View Code</a
+              >View Project</a
             >
           </div>
           <div class="project-card">


### PR DESCRIPTION
Introduce a new project card for the Commander Deck Tuner, detailing its purpose, technologies used, and providing a link to the project repository.