### PR TITLE
Remove unnecessary blank line in project description

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,7 +20,6 @@ import Layout from "../layouts/Layout.astro";
             their Commander (EDH) decks. The app provides deck statistics, card
             suggestions, and easy deck editing features.
           </p>
-
           <p>🛠️ <strong>Tech Stack:</strong></p>
           <ul>
             <li>Frontend: React, Vite, Axios, React Toastify</li>


### PR DESCRIPTION
Eliminate an extra blank line in the project description for improved readability.